### PR TITLE
set 0.8.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -33,6 +34,9 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 ToStruct = "43ec2cc1-0e50-5406-a854-b7ff8fdb8dad"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Unrolled = "9602ed7d-8fef-5bc8-8597-8f21381861e8"
+
+[compat]
+NNlib="=0.8.2"
 
 [extras]
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"


### PR DESCRIPTION
This PR specifies the version of NNlib v0.8.2. The current release v0.8.3 does not backprop properly on trainings using GPU.