### PR TITLE
improve performance of `calc_action`

### DIFF
--- a/src/actions.jl
+++ b/src/actions.jl
@@ -10,13 +10,14 @@ function calc_action(
     potential = @. action.m² * cfgs^2 + action.λ * cfgs^4
     sz = length(size(cfgs))
     Nd = sz - 1 # exclude last axis
-    k1 = sum(2cfgs .^ 2 for μ in 1:Nd)
+    B = size(cfgs, sz) # batch size
+    k1 = Nd * 2cfgs .^ 2
     k2 = sum(cfgs .* circshift(cfgs, -Flux.onehot(μ, 1:sz)) for μ in 1:Nd)
     k3 = sum(cfgs .* circshift(cfgs, Flux.onehot(μ, 1:sz)) for μ in 1:Nd)
     action_density = potential .+ k1 .- k2 .- k3
-    dropdims(
+    reshape(
         sum(action_density, dims=1:Nd),
-        dims=Tuple(1:Nd),
+        B
     )
 end
 


### PR DESCRIPTION
🎉 

```julia
julia> @btime calc_action($action, $cfgs); # previous

  358.105 μs (1125 allocations: 76.97 KiB)

julia> @btime calc_action2($action, $cfgs); # this pr
  299.799 μs (954 allocations: 65.41 KiB)

julia> @btime gradient(sum ∘ Base.Fix1(calc_action, action), $cfgs); # previous
  2.217 ms (3867 allocations: 227.20 KiB)

julia> @btime gradient(sum ∘ Base.Fix1(calc_action2, action), $cfgs); # this pr
  1.925 ms (3229 allocations: 190.64 KiB)
```