### PR TITLE
Use julia 1.8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
         version:
           - '1.6'
           - '1.7'
+          - '1.8'
         os:
           - ubuntu-latest
         arch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
 
 ENV JULIA_PATH /usr/local/julia
 ENV PATH $JULIA_PATH/bin:$PATH
@@ -109,7 +109,8 @@ RUN mkdir -p ${HOME}/.jupyter/lab/user-settings/@jupyterlab/shortcuts-extension 
 
 RUN wget https://raw.githubusercontent.com/mwouts/jupytext/main/binder/labconfig/default_setting_overrides.json -P  ~/.jupyter/labconfig/
 
-RUN conda install -y seaborn matplotlib pytorch=1.9 torchvision torchaudio cudatoolkit=11.1 -c pytorch -c nvidia && \
+RUN conda install -y seaborn matplotlib -c conda-forge && \
+    conda install pytorch=1.12 torchvision torchaudio cudatoolkit=11.3 -c pytorch && \
     conda clean -afy # clean up
 
 # Install extras

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Julia
-RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.7/julia-1.7.3-linux-x86_64.tar.gz && \
+RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-1.8.0-linux-x86_64.tar.gz && \
     mkdir "$JULIA_PATH" && \
-    tar zxvf julia-1.7.3-linux-x86_64.tar.gz -C "$JULIA_PATH" --strip-components 1 && \
-    rm julia-1.7.3-linux-x86_64.tar.gz # clean up
+    tar zxvf julia-1.8.0-linux-x86_64.tar.gz -C "$JULIA_PATH" --strip-components 1 && \
+    rm julia-1.8.0-linux-x86_64.tar.gz # clean up
 
 # Create user named jovyan which is compatible with Binder
 ARG NB_USER=jovyan

--- a/Project.toml
+++ b/Project.toml
@@ -40,12 +40,12 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
 BSON = "0.3.5"
-Flux = "0.13.4"
+Flux = "0.13.5"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 
 [targets]
 test = ["Test", "ImageFiltering", "BenchmarkTools"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,7 +152,9 @@ end
 # PotentialDistributions.jl
 include("potential.jl")
 
-include("pyinterface.jl")
+if get(ENV, "CI", false)
+    include("pyinterface.jl")
+end
 
 # Action
 include("actions.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,7 +152,7 @@ end
 # PotentialDistributions.jl
 include("potential.jl")
 
-if get(ENV, "CI", false)
+if get(ENV, "CI", "false") == "true"
     include("pyinterface.jl")
 end
 


### PR DESCRIPTION
This pull request adopts Julia 1.8 as the execution environment.

The current version of Julia 1.8 does not allow PyTorch to be called via PyCall (=Conda environment).
Ref https://discourse.julialang.org/t/glibcxx-version-not-found/82209

Therefore we skipped running test "pyinterface.jl" locally.