### PR TITLE
add $(Sys.ARCH)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ USER ${NB_USER}
 # Install basic packages on default environment
 RUN julia -e 'using Pkg; Pkg.add(["PyCall", "IJulia", "Pluto", "PlutoUI", "Revise", "BenchmarkTools"]); Pkg.precompile()'
 
-ENV PATH $PATH:${HOME}/.julia/conda/3/bin
+ENV PATH $PATH:${HOME}/.julia/conda/3/x86_64/bin
 
 # Install packages for Jupyter Notebook/JupyterLab
 RUN conda install -y -c conda-forge \


### PR DESCRIPTION
It seems we should update /path/to/conda  equivalent to `Conda.BINDIR`. 
`Sys.ARCH` is included in `Conda.ROOTENV` on which `Conda.BINDIR` depends.

https://github.com/JuliaPy/Conda.jl/blame/81fe00cb0388c8ea58f9244a0de0f9c5dd3534a1/deps/build.jl#L14 

Ref https://github.com/JuliaPy/Conda.jl/pull/232